### PR TITLE
fix: pass modified files to the Action

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,12 +33,16 @@ two commits and get a list of modified files.
           with:
             fetch-depth: 2
 
+        - name: Get modified files
+          run: export MODIFIED_FILES=`git diff HEAD^ --name-only | xargs`
+
         - name: Wiki Sync
-          uses: talkiq/confluence-docs-sync@v1
+          uses: talkiq/confluence-wiki-sync@v1
           with:
             wiki-base-url: https://example.org
             user: user@domain.tld
             token: ${{ secrets.TOKEN }}
+            modified-files: ${{ env.MODIFIED_FILES }}
             space-name: CoolSpace
             root-page-title: Root page
 
@@ -57,7 +61,7 @@ space-separated list:
 .. code-block:: yaml
 
   - name: Wiki Sync
-    uses: talkiq/confluence-docs-sync@v1
+    uses: talkiq/confluence-wiki-sync@v1
     with:
       ignored_folders: 'foo/ bar/baz/'
       [...]

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ two commits and get a list of modified files.
             fetch-depth: 2
 
         - name: Get modified files
-          run: export MODIFIED_FILES=`git diff HEAD^ --name-only | xargs`
+          run: echo "MODIFIED_FILES=`git diff HEAD^ --name-only | xargs`" >> $GITHUB_ENV
 
         - name: Wiki Sync
           uses: talkiq/confluence-wiki-sync@v1

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
     description: Space-delimited list of folders to ignore when considering which files to upload
     required: false
     default: ''
+  modified-files:
+    description: Space-delimited list of files that have been modified (or added or deleted)
+    required: true
   root-page-title:
     description: Title of the Confluence page files will be uploaded under
     required: true

--- a/main.py
+++ b/main.py
@@ -13,11 +13,8 @@ import atlassian
 import pypandoc
 
 
-def get_files_to_sync() -> List[str]:
-    with subprocess.Popen(['git', 'diff', 'HEAD^', '--name-only'],
-                          stdout=subprocess.PIPE) as proc:
-        changed_files = proc.communicate()[0].rstrip().decode('utf-8')
-        return [f for f in changed_files.split('\n') if should_sync_file(f)]
+def get_files_to_sync(changed_files: str) -> List[str]:
+    return [f for f in changed_files.split() if should_sync_file(f)]
 
 
 def should_sync_file(file_name: str) -> bool:
@@ -156,7 +153,7 @@ if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)
 
     try:
-        files_to_sync = get_files_to_sync()
+        files_to_sync = get_files_to_sync(os.environ['INPUT_MODIFIED-FILES'])
         logging.info('Files to be synced: %s', files_to_sync)
 
         had_sync_errors = sync_files(files_to_sync)


### PR DESCRIPTION
The Python script now reads the list of modified files as a parameter, instead of calling `git diff` itself.

This fixes #2 because the Python script no longer needs to be run inside the repository.