### PR TITLE
#18 Embed images

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,7 @@ repos:
         - -d import-error
         - -d invalid-name
         - -d missing-docstring
+        - -d no-else-return
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 4.0.1
     hooks:

--- a/tests/test_relative_links.py
+++ b/tests/test_relative_links.py
@@ -117,7 +117,6 @@ def test_link_to_file_in_parent_folder(wiki_mock, get_repo_root_mock):
         assert output == expected_output
 
 
-@pytest.mark.xfail(reason='Will be implemented in #19')
 def test_simplified_link(wiki_mock, get_repo_root_mock):
     # Link where the name of the link is the same as the link itself
     with tempfile.TemporaryDirectory() as repo_root:
@@ -137,7 +136,7 @@ def test_simplified_link(wiki_mock, get_repo_root_mock):
         output = wiki_sync.get_formatted_file_content(
                 wiki_mock, doc_path, GH_ROOT, REPO_NAME)
 
-        expected_link = f'[{linked_file_name}|{GH_ROOT}{linked_doc_path}'
+        expected_link = f'[{linked_file_name}|{GH_ROOT}{linked_doc_path}]'
         assert output == f'Check out {expected_link}\n'
 
 

--- a/tests/test_relative_links.py
+++ b/tests/test_relative_links.py
@@ -64,7 +64,7 @@ def test_link_to_file_in_same_folder(wiki_mock, get_repo_root_mock):
         output = wiki_sync.get_formatted_file_content(
                 wiki_mock, doc_path, GH_ROOT, REPO_NAME)
 
-        expected_output = (f'Check out this'
+        expected_output = ('Check out this'
                            f' [other file|{GH_ROOT}{linked_doc_path}]\n')
         assert output == expected_output
 
@@ -88,7 +88,7 @@ def test_link_to_file_in_child_folder(wiki_mock, get_repo_root_mock):
         output = wiki_sync.get_formatted_file_content(
                 wiki_mock, doc_path, GH_ROOT, REPO_NAME)
 
-        expected_output = (f'Check out this'
+        expected_output = ('Check out this'
                            f' [other file|{GH_ROOT}{linked_doc_path}]\n')
         assert output == expected_output
 
@@ -112,7 +112,7 @@ def test_link_to_file_in_parent_folder(wiki_mock, get_repo_root_mock):
         output = wiki_sync.get_formatted_file_content(
                 wiki_mock, doc_path, GH_ROOT, REPO_NAME)
 
-        expected_output = (f'Check out this'
+        expected_output = ('Check out this'
                            f' [other file|{GH_ROOT}{linked_doc_path}]\n')
         assert output == expected_output
 
@@ -187,6 +187,34 @@ def test_link_to_file_that_exists_on_confluence(wiki_mock, get_repo_root_mock):
         wiki_link = 'http://mywiki.atlassian.net/wiki/spaces/SPACE/pages/123'
         expected_output = (f'Check out this [other file|{wiki_link}]\n')
         assert output == expected_output
+
+
+def test_simple_link_to_image(wiki_mock, get_repo_root_mock):
+    with tempfile.TemporaryDirectory() as repo_root:
+        get_repo_root_mock.return_value = repo_root
+
+        # Create a file that the doc will link to
+        linked_file_name = 'cool_image.png'
+        linked_doc_path = os.path.join(repo_root, linked_file_name)
+        # The file isn't actually an image, but that's not important
+        write_something_to_file(linked_doc_path)
+
+        # Create the doc file with a link to the other one
+        doc_path = os.path.join(repo_root, 'new_doc.md')
+        with open(doc_path, mode='w', encoding='utf-8') as doc_file:
+            contents = f'Check out ![]({linked_file_name})'
+            print(contents, file=doc_file)
+
+        output = wiki_sync.get_formatted_file_content(
+                wiki_mock, doc_path, GH_ROOT, REPO_NAME)
+
+        expected_output = ('Check out '
+                           f' !notthis!\n')
+        assert output == expected_output
+
+
+def test_link_to_image_with_params(wiki_mock, get_repo_root_mock):
+    del wiki_mock, get_repo_root_mock
 
 
 def write_something_to_file(file_path: str) -> None:

--- a/wiki_sync.py
+++ b/wiki_sync.py
@@ -193,18 +193,18 @@ def _replace_relative_links(wiki_client: atlassian.Confluence, file_path: str,
 
             # TODO This doesn't handle the case of a doc file including two
             # different images with the same file name
-            logging.info('Looking for an attachment named %s', file_name)
+            logging.debug('Looking for an attachment named %s', file_name)
             attachments = wiki_client.get_attachments_from_content(
                     page_id, filename=file_name)['results']
 
             if attachments:
-                logging.info('%s attachment(s) found', len(attachments))
+                logging.debug('%s attachment(s) found', len(attachments))
                 # TODO Figure out whether we want to update the image
                 # The API doesn't tell us when the file was last updated, so we
                 # can't compare that to the last commit on that file
             else:
-                logging.info('No attachment found - attaching file %s',
-                             link.target_path)
+                logging.info('Attaching file %s to page %s',
+                             link.target_path, page_id)
                 wiki_client.attach_file(
                         filename=link.target_path, page_id=page_id)
 
@@ -245,19 +245,10 @@ def _extract_relative_links(file_path: str, file_contents: str,
         if rel_link.startswith('http'):
             continue
 
-        # TMP
-        logging.debug(file_path)
-        logging.debug(os.path.split(file_path)[0])
-        logging.debug(rel_link)
-
         target_path = os.path.join(os.path.split(file_path)[0], rel_link)
-        logging.debug(target_path)
         target_path = os.path.normpath(target_path)
-        logging.debug(target_path)
         if not os.path.exists(target_path):  # Not actually a relative link
-            logging.debug("%s doesn't exist", target_path)
             continue
-        logging.debug('%s exists', target_path)
 
         links.append(RelativeLink(link_type=link_type,
                                   text=text,
@@ -350,7 +341,8 @@ def create_or_update_pages_for_file(wiki_client: atlassian.Confluence,
 
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
+    logging.basicConfig(level=logging.INFO)
+    logging.getLogger('atlassian.confluence').setLevel(logging.INFO)
     logging.getLogger('atlassian.rest_client').setLevel(logging.INFO)
     logging.getLogger('urllib3.connectionpool').setLevel(logging.INFO)
 

--- a/wiki_sync.py
+++ b/wiki_sync.py
@@ -19,10 +19,10 @@ import pypandoc
 # The format of a link in JIRA markdown is [link name|link]
 JIRA_LINK_PATTERN = re.compile(r'\[(.+)\|(.+)\]')
 # If the link doesn't have a name, then it's simply [link]
-JIRA_UNNAMED_LINK_PATTERN = re.compile(r'\[([^|]+)\]')
+JIRA_UNNAMED_LINK_PATTERN = re.compile(r'\[([^|\n]+)\]')
 # The format of an image in JIRA markdown is
 # !filename.png! or !some_pic.png|alt=image!
-JIRA_SIMPLE_IMG_PATTERN = re.compile(r'!([^|]+)!')
+JIRA_SIMPLE_IMG_PATTERN = re.compile(r'!([^|\n]+)!')
 JIRA_IMG_PATTERN_WITH_PARAMS = re.compile(r'!(.+)\|(.+)!')
 
 
@@ -248,7 +248,6 @@ def _extract_relative_links(file_path: str, file_contents: str,
         # TMP
         logging.debug(file_path)
         logging.debug(os.path.split(file_path)[0])
-        logging.debug(os.path.split(file_path)[0])
         logging.debug(rel_link)
 
         target_path = os.path.join(os.path.split(file_path)[0], rel_link)
@@ -256,9 +255,9 @@ def _extract_relative_links(file_path: str, file_contents: str,
         target_path = os.path.normpath(target_path)
         logging.debug(target_path)
         if not os.path.exists(target_path):  # Not actually a relative link
-            logging.debug("%s doesn't exist")
+            logging.debug("%s doesn't exist", target_path)
             continue
-        logging.debug('%s exists')
+        logging.debug('%s exists', target_path)
 
         links.append(RelativeLink(link_type=link_type,
                                   text=text,

--- a/wiki_sync.py
+++ b/wiki_sync.py
@@ -206,7 +206,7 @@ def _replace_relative_links(wiki_client: atlassian.Confluence, file_path: str,
                 logging.info('No attachment found - attaching file %s',
                              link.target_path)
                 wiki_client.attach_file(
-                        filename=file_name, page_id=page_id)
+                        filename=link.target_path, page_id=page_id)
 
             link.wiki_link = file_name
 

--- a/wiki_sync.py
+++ b/wiki_sync.py
@@ -245,10 +245,20 @@ def _extract_relative_links(file_path: str, file_contents: str,
         if rel_link.startswith('http'):
             continue
 
+        # TMP
+        logging.debug(file_path)
+        logging.debug(os.path.split(file_path)[0])
+        logging.debug(os.path.split(file_path)[0])
+        logging.debug(rel_link)
+
         target_path = os.path.join(os.path.split(file_path)[0], rel_link)
+        logging.debug(target_path)
         target_path = os.path.normpath(target_path)
+        logging.debug(target_path)
         if not os.path.exists(target_path):  # Not actually a relative link
+            logging.debug("%s doesn't exist")
             continue
+        logging.debug('%s exists')
 
         links.append(RelativeLink(link_type=link_type,
                                   text=text,
@@ -343,6 +353,7 @@ def create_or_update_pages_for_file(wiki_client: atlassian.Confluence,
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
     logging.getLogger('atlassian.rest_client').setLevel(logging.INFO)
+    logging.getLogger('urllib3.connectionpool').setLevel(logging.INFO)
 
     try:
         files_to_sync = get_files_to_sync(os.environ['INPUT_MODIFIED-FILES'])


### PR DESCRIPTION
Closes #18, #19

The idea is to attach the file to the wiki page. The tricky bit will be to figure out when to update it (what if you update an image but not the document(s) that use it?), but we can worry about that later. Having an initial version of the image is better than the current situation.