### PR TITLE
fix: Use relative path to create GitHub links, fix regex

### DIFF
--- a/tests/test_relative_links.py
+++ b/tests/test_relative_links.py
@@ -41,12 +41,12 @@ def test_http_link(wiki_mock, get_repo_root_mock):
             print('Check out this [link](https://example.org)', file=doc_file)
 
         output = wiki_sync.get_formatted_file_content(
-                wiki_mock, doc_path, GH_ROOT, REPO_NAME)
+                wiki_mock, repo_root, doc_path, GH_ROOT, REPO_NAME)
 
         assert output == 'Check out this [link|https://example.org]\n'
 
 
-def test_link_to_file_in_same_folder(wiki_mock, get_repo_root_mock):
+def test_link_to_file_both_in_root(wiki_mock, get_repo_root_mock):
     with tempfile.TemporaryDirectory() as repo_root:
         get_repo_root_mock.return_value = repo_root
 
@@ -62,10 +62,34 @@ def test_link_to_file_in_same_folder(wiki_mock, get_repo_root_mock):
             print(contents, file=doc_file)
 
         output = wiki_sync.get_formatted_file_content(
-                wiki_mock, doc_path, GH_ROOT, REPO_NAME)
+                wiki_mock, repo_root, doc_path, GH_ROOT, REPO_NAME)
 
-        expected_output = (f'Check out this'
-                           f' [other file|{GH_ROOT}{linked_doc_path}]\n')
+        expected_gh_link = f'{GH_ROOT}{linked_file_name}'
+        expected_output = f'Check out this [other file|{expected_gh_link}]\n'
+        assert output == expected_output
+
+
+def test_link_to_file_in_same_non_root_folder(wiki_mock, get_repo_root_mock):
+    with tempfile.TemporaryDirectory() as repo_root:
+        get_repo_root_mock.return_value = repo_root
+
+        os.makedirs(os.path.join(repo_root, 'foo'))
+        # Create a file that the doc will link to
+        linked_file_name = 'linked_file.py'
+        linked_doc_path = os.path.join(repo_root, 'foo', linked_file_name)
+        write_something_to_file(linked_doc_path)
+
+        # Create the doc file with a link to the other one
+        doc_path = os.path.join(repo_root, 'foo', 'new_doc.md')
+        with open(doc_path, mode='w', encoding='utf-8') as doc_file:
+            contents = f'Check out this [other file]({linked_file_name})'
+            print(contents, file=doc_file)
+
+        output = wiki_sync.get_formatted_file_content(
+                wiki_mock, repo_root, doc_path, GH_ROOT, REPO_NAME)
+
+        expected_gh_link = f'{GH_ROOT}foo/{linked_file_name}'
+        expected_output = f'Check out this [other file|{expected_gh_link}]\n'
         assert output == expected_output
 
 
@@ -86,10 +110,10 @@ def test_link_to_file_in_child_folder(wiki_mock, get_repo_root_mock):
             print(contents, file=doc_file)
 
         output = wiki_sync.get_formatted_file_content(
-                wiki_mock, doc_path, GH_ROOT, REPO_NAME)
+                wiki_mock, repo_root, doc_path, GH_ROOT, REPO_NAME)
 
-        expected_output = (f'Check out this'
-                           f' [other file|{GH_ROOT}{linked_doc_path}]\n')
+        expected_gh_link = f'{GH_ROOT}foo/bar/linked_file.py'
+        expected_output = f'Check out this [other file|{expected_gh_link}]\n'
         assert output == expected_output
 
 
@@ -110,10 +134,10 @@ def test_link_to_file_in_parent_folder(wiki_mock, get_repo_root_mock):
             print(contents, file=doc_file)
 
         output = wiki_sync.get_formatted_file_content(
-                wiki_mock, doc_path, GH_ROOT, REPO_NAME)
+                wiki_mock, repo_root, doc_path, GH_ROOT, REPO_NAME)
 
-        expected_output = (f'Check out this'
-                           f' [other file|{GH_ROOT}{linked_doc_path}]\n')
+        expected_gh_link = f'{GH_ROOT}linked_file.py'
+        expected_output = f'Check out this [other file|{expected_gh_link}]\n'
         assert output == expected_output
 
 
@@ -135,9 +159,9 @@ def test_simplified_link(wiki_mock, get_repo_root_mock):
             print(contents, file=doc_file)
 
         output = wiki_sync.get_formatted_file_content(
-                wiki_mock, doc_path, GH_ROOT, REPO_NAME)
+                wiki_mock, repo_root, doc_path, GH_ROOT, REPO_NAME)
 
-        expected_link = f'[{linked_file_name}|{GH_ROOT}{linked_doc_path}'
+        expected_link = f'[{linked_file_name}|{GH_ROOT}linked_file.py'
         assert output == f'Check out {expected_link}\n'
 
 
@@ -152,8 +176,9 @@ def test_link_to_non_existing_file(wiki_mock, get_repo_root_mock):
             print(contents, file=doc_file)
 
         output = wiki_sync.get_formatted_file_content(
-                wiki_mock, doc_path, GH_ROOT, REPO_NAME)
+                wiki_mock, repo_root, doc_path, GH_ROOT, REPO_NAME)
 
+        # Output is the same
         assert output == 'Check out this [other file|non_existing.py]\n'
 
 
@@ -183,7 +208,7 @@ def test_link_to_file_that_exists_on_confluence(wiki_mock, get_repo_root_mock):
             print(contents, file=doc_file)
 
         output = wiki_sync.get_formatted_file_content(
-                wiki_mock, doc_path, GH_ROOT, REPO_NAME)
+                wiki_mock, repo_root, doc_path, GH_ROOT, REPO_NAME)
 
         wiki_link = 'http://mywiki.atlassian.net/wiki/spaces/SPACE/pages/123'
         expected_output = (f'Check out this [other file|{wiki_link}]\n')

--- a/tests/test_relative_links.py
+++ b/tests/test_relative_links.py
@@ -183,7 +183,10 @@ def test_link_to_non_existing_file(wiki_mock, get_repo_root_mock):
 
 
 def test_link_to_file_that_exists_on_confluence(wiki_mock, get_repo_root_mock):
-    os.environ['INPUT_WIKI-BASE-URL'] = 'http://mywiki.atlassian.net'
+    space = 'WikiSpace'
+    os.environ['INPUT_SPACE-NAME'] = space
+    wiki_url = 'http://mywiki.atlassian.net'
+    os.environ['INPUT_WIKI-BASE-URL'] = wiki_url
 
     with tempfile.TemporaryDirectory() as repo_root:
         get_repo_root_mock.return_value = repo_root
@@ -197,7 +200,7 @@ def test_link_to_file_that_exists_on_confluence(wiki_mock, get_repo_root_mock):
         # existing Confluence page, say yes
         wiki_mock.get_page_by_title.return_value = {
             '_links': {
-                'webui': '/spaces/SPACE/pages/123'
+                'webui': f'/spaces/{space}/pages/123'
                 }
             }
 
@@ -210,9 +213,12 @@ def test_link_to_file_that_exists_on_confluence(wiki_mock, get_repo_root_mock):
         output = wiki_sync.get_formatted_file_content(
                 wiki_mock, repo_root, doc_path, GH_ROOT, REPO_NAME)
 
-        wiki_link = 'http://mywiki.atlassian.net/wiki/spaces/SPACE/pages/123'
+        wiki_link = f'{wiki_url}/wiki/spaces/{space}/pages/123'
         expected_output = (f'Check out this [other file|{wiki_link}]\n')
         assert output == expected_output
+
+        wiki_mock.get_page_by_title.assert_called_once_with(
+                space, f'{REPO_NAME}/linked_file.py')
 
 
 def write_something_to_file(file_path: str) -> None:

--- a/wiki_sync.py
+++ b/wiki_sync.py
@@ -136,8 +136,11 @@ def get_formatted_file_content(wiki_client: atlassian.Confluence,
         if not os.path.exists(target_path):  # Not actually a relative link
             continue
 
+        target_from_root = os.path.relpath(target_path, start=repo_root)
+
         wiki_page_info = wiki_client.get_page_by_title(
-                os.environ['INPUT_SPACE-NAME'], f'{repo_name}/{target_path}')
+                os.environ['INPUT_SPACE-NAME'],
+                f'{repo_name}/{target_from_root}')
         if wiki_page_info:
             # The link is to a file that has a Confluence page
             # Let's link to the page directly
@@ -146,7 +149,6 @@ def get_formatted_file_content(wiki_client: atlassian.Confluence,
             links_to_replace[link] = target_page_url
         else:
             # No existing Confluence page - link to GitHub
-            target_from_root = os.path.relpath(target_path, start=repo_root)
             links_to_replace[link] = gh_root + target_from_root
 
     # Replace relative links

--- a/wiki_sync.py
+++ b/wiki_sync.py
@@ -18,7 +18,7 @@ import pypandoc
 # We only need a capture group for the link itself
 # TODO handle links like [link], which happen when the link name is the same as
 # the link itself
-JIRA_LINK_PATTERN = re.compile(r'\[.*\|(.*)\]')
+JIRA_LINK_PATTERN = re.compile(r'\[[^|\n]+\|([^|\n]+)\]')
 
 
 def get_files_to_sync(changed_files: str) -> List[str]:


### PR DESCRIPTION
When checking whether a file has an existing Confluence page, and when linking to GitHub, use the file path relative to the repo root and not relative to the root of the machine that is running the wiki sync script.

Also update the regex that find links, so that multiple links on the same line are parsed properly.

Fixes #34 #36 