### PR TITLE
chore: Upgrade pylint to latest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     -   id: check-ast
     -   id: debug-statements
 -   repo: https://github.com/pycqa/pylint
-    rev: v2.12.2
+    rev: v2.15.5
     hooks:
     -   id: pylint
         args:


### PR DESCRIPTION
CircleCI started running test on Python 3.11, and we ran into https://github.com/PyCQA/pylint/issues/5919. Upgrading to latest should fix the problem.

Might be good to avoid upgrading Python versions automatically. We should keep CircleCI in sync with the image defined in the Dockerfile.