### PR TITLE
infra: Fetch flake8 from GitHub instead of GitLab

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         - -d import-error
         - -d invalid-name
         - -d missing-docstring
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: 4.0.1
     hooks:
     -   id: flake8


### PR DESCRIPTION
Fixes
```
[INFO] Initializing environment for https://gitlab.com/pycqa/flake8.
Username for 'https://gitlab.com': Username for 'https://gitlab.com': An unexpected error has occurred: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags')
return code: 128
stdout: (none)
stderr:
    fatal: could not read Username for 'https://gitlab.com': Success
    
Check the log at /root/.cache/pre-commit/pre-commit.log

Exited with code exit status 3
```
https://app.circleci.com/pipelines/github/talkiq/confluence-wiki-sync/113/workflows/f4e50bb7-af64-45c8-aa8e-6afb0e82c87e/jobs/220