### PR TITLE
Fix tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,9 @@ jobs:
       - image: pandoc/core:latest-ubuntu
     steps:
       - checkout
-      - run: apt update && apt install -y pip
+      # Set DEBIAN_FRONTEND to avoid tzdata interactive input
+      # https://techoverflow.net/2019/05/18/how-to-fix-configuring-tzdata-interactive-input-when-building-docker-images/
+      - run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y pip
       - run: pip install -r requirements.txt
       - run: pip install pytest
       - run: pytest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,8 @@ jobs:
       - checkout
       # Set DEBIAN_FRONTEND to avoid tzdata interactive input
       # https://techoverflow.net/2019/05/18/how-to-fix-configuring-tzdata-interactive-input-when-building-docker-images/
-      - run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y pip
+      - run: export DEBIAN_FRONTEND=noninteractive
+      - run: apt-get update && apt-get install -y pip
       - run: pip install -r requirements.txt
       - run: pip install pytest
       - run: pytest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,11 +7,12 @@ jobs:
   run-tests:
     docker:
       - image: pandoc/core:latest-ubuntu
-    steps:
-      - checkout
+    environment:
       # Set DEBIAN_FRONTEND to avoid tzdata interactive input
       # https://techoverflow.net/2019/05/18/how-to-fix-configuring-tzdata-interactive-input-when-building-docker-images/
-      - run: export DEBIAN_FRONTEND=noninteractive
+      DEBIAN_FRONTEND: noninteractive
+    steps:
+      - checkout
       - run: apt-get update && apt-get install -y pip
       - run: pip install -r requirements.txt
       - run: pip install pytest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,7 @@ jobs:
     steps:
       - checkout
       - run: apt-get update && apt-get install -y pip
-      - run:
-        command: |
+      - run: |
           python3 -m venv venv
           source venv/bin/activate
           pip install -r requirements.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,13 @@ jobs:
     steps:
       - checkout
       - run: apt-get update && apt-get install -y pip
-      - run: pip install -r requirements.txt
-      - run: pip install pytest
-      - run: pytest
+      - run:
+        command: |
+          python3 -m venv venv
+          source venv/bin/activate
+          pip install -r requirements.txt
+          pip install pytest
+          pytest
 
 workflows:
   run-jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       DEBIAN_FRONTEND: noninteractive
     steps:
       - checkout
-      - run: apt-get update && apt-get install -y pip
+      - run: apt-get update && apt-get install -y python3-venv pip
       - run: |
           python3 -m venv venv
           source venv/bin/activate


### PR DESCRIPTION
Fixes #61 

This fixes two problems:
* `apt update && apt install -y pip` was getting stuck on an interactive prompt when installing tz
* Python now forces the use of virtualenvs