### PR TITLE
feat: Add support for images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install git pandoc -y
 COPY requirements.txt /requirements.txt
 RUN pip install -r /requirements.txt
 
-COPY wiki_sync.py /wiki_sync.py
+COPY *.py /
 
 ENTRYPOINT ["python3"]
 CMD ["/wiki_sync.py"]

--- a/content_converter.py
+++ b/content_converter.py
@@ -1,0 +1,225 @@
+import dataclasses
+import enum
+import logging
+import os
+import re
+
+import atlassian
+import pypandoc
+
+
+# GENERAL NOTE about the regex patterns: we want them to be non-greedy
+# https://docs.python.org/3/howto/regex.html#greedy-versus-non-greedy
+
+# The format of a link in JIRA markdown is [link name|link]
+JIRA_LINK_PATTERN = re.compile(r'\[(.+?)\|(.+?)\]')
+# If the link doesn't have a name, then it's simply [link]
+JIRA_UNNAMED_LINK_PATTERN = re.compile(r'\[([^|\n]+?)\]')
+# The format of an image in JIRA markdown is
+# !filename.png! or !some_pic.png|alt=image!
+JIRA_SIMPLE_IMG_PATTERN = re.compile(r'!([^|\n]+?)!')
+JIRA_IMG_PATTERN_WITH_PARAMS = re.compile(r'!(.+?)\|(.+?)!')
+
+
+class RelativeLinkType(enum.Enum):
+    GENERIC = 0  # [text|link] or [link]
+    IMAGE = 1  # !file.ext|alt=text! or !file.ext!
+
+
+@dataclasses.dataclass
+class RelativeLink:
+    """Represents a relative link
+
+    Contains information to allow updating the link to something that works on wiki"""
+
+    link_type: RelativeLinkType
+    text: str  # Text associated with the link (link name, alt text, ...)
+    original_link: str  # Link in the original document. Relative to said document.
+    target_path: str  # Path of the file being linked to, from repository root
+    wiki_link: str  # Link to be used in the final wiki page
+
+
+class ContentConverter:
+    """A wrapper around Pandoc, with Confluence-specific improvements
+
+    After conversion to JIRA markdown, fixes relative links and keeps a list of files to
+    be attached to the page later"""
+
+    def __init__(
+        self,
+        wiki_client: atlassian.Confluence,
+        repo_root: str,
+        gh_root: str,
+        repo_name: str,
+    ) -> str:
+        self.wiki_client = wiki_client
+        self.repo_root = repo_root
+        self.gh_root = gh_root
+        self.repo_name = repo_name
+
+        self.files_to_attach_to_last_page: list[str] = []
+
+    def convert_file_contents(self, file_path: str) -> str:
+        self.files_to_attach_to_last_page = []
+
+        absolute_file_path = os.path.join(self.repo_root, file_path)
+        formated_file_contents = pypandoc.convert_file(absolute_file_path, 'jira')
+
+        return self._replace_relative_links(file_path, formated_file_contents)
+
+    def _replace_relative_links(self, file_path: str, contents: str) -> str:
+        links: list[RelativeLink] = []
+
+        for pattern in (
+            JIRA_LINK_PATTERN,
+            JIRA_UNNAMED_LINK_PATTERN,
+            JIRA_SIMPLE_IMG_PATTERN,
+            JIRA_IMG_PATTERN_WITH_PARAMS,
+        ):
+            links.extend(self._extract_relative_links(file_path, contents, pattern))
+
+        if links:
+            logging.debug(
+                'Found %s relative links in %s: %s', len(links), file_path, links
+            )
+
+        for link in links:
+            # First we decide what the wiki link will be
+            if link.link_type == RelativeLinkType.GENERIC:
+                wiki_page_name = f'{self.repo_name}/{link.target_path}'
+                wiki_page_info = self.wiki_client.get_page_by_title(
+                    os.environ['INPUT_SPACE-NAME'], wiki_page_name
+                )
+                if wiki_page_info:
+                    # The link is to a file that has a Confluence page
+                    # Let's link to the page directly
+                    target_page_url = (
+                        os.environ['INPUT_WIKI-BASE-URL']
+                        + '/wiki'
+                        + wiki_page_info['_links']['webui']
+                    )
+                    link.wiki_link = target_page_url
+                else:
+                    # No existing Confluence page - link to GitHub
+                    link.wiki_link = self.gh_root + link.target_path
+
+            elif link.link_type == RelativeLinkType.IMAGE:
+                _, attachment_name = os.path.split(link.target_path)
+                link.wiki_link = attachment_name
+
+                wiki_page_name = f'{self.repo_name}/{file_path}'
+                page_id = self.wiki_client.get_page_id(
+                    os.environ['INPUT_SPACE-NAME'], wiki_page_name
+                )
+
+                if page_id:
+                    self._attach_to_page(page_id, link.target_path)
+                else:  # Page doesn't exist yet (is being created)
+                    logging.debug(
+                        "%s needs to be attached to page %s, which hasn't"
+                        ' been created yet',
+                        link.target_path,
+                        wiki_page_name,
+                    )
+                    self.files_to_attach_to_last_page.append(link.target_path)
+
+            else:
+                raise Exception(f'Unexpected relative link type {link.link_type}')
+
+            # Then we replace the relative links
+            contents = self._replace_relative_link(contents, link)
+
+        return contents
+
+    def _extract_relative_links(
+        self, file_path: str, file_contents: str, pattern: re.Pattern
+    ) -> list[RelativeLink]:
+        links: list[RelativeLink] = []
+
+        for matching_groups in re.findall(pattern, file_contents):
+            text = target = ''
+            link_type = RelativeLinkType.GENERIC
+            if pattern == JIRA_LINK_PATTERN:
+                text = matching_groups[0]
+                target = matching_groups[1]
+            elif pattern == JIRA_UNNAMED_LINK_PATTERN:
+                text = target = matching_groups
+            elif pattern == JIRA_SIMPLE_IMG_PATTERN:
+                link_type = RelativeLinkType.IMAGE
+                text = target = matching_groups
+            elif pattern == JIRA_IMG_PATTERN_WITH_PARAMS:
+                link_type = RelativeLinkType.IMAGE
+                text = matching_groups[1]
+                target = matching_groups[0]
+            else:
+                raise Exception(f'Unexpected link pattern {pattern}')
+
+            # Most links are HTTP(S) and therefore not relative links - don't waste time
+            if target.startswith('http'):
+                continue
+
+            # Find the absolute path of the target file
+            file_abs_path = os.path.join(self.repo_root, file_path)
+            file_abs_dir = os.path.dirname(file_abs_path)
+            target_abs_path = os.path.normpath(os.path.join(file_abs_dir, target))
+            if not os.path.exists(target_abs_path):  # Not actually a relative link
+                continue
+
+            # Now find the path from repo root to the target file
+            target_path = target_abs_path.removeprefix(self.repo_root).removeprefix('/')
+
+            links.append(
+                RelativeLink(
+                    link_type=link_type,
+                    text=text,
+                    original_link=target,
+                    target_path=target_path,
+                    wiki_link='',  # Will be filled in later
+                )
+            )
+
+        return links
+
+    def _replace_relative_link(self, text: str, link: RelativeLink) -> str:
+        if link.link_type == RelativeLinkType.GENERIC:
+            if link.text == link.original_link:
+                # This means the JIRA markdown is simply [link]
+                # Keep the text and update the link
+                return text.replace(
+                    f'[{link.original_link}]', f'[{link.text}|{link.wiki_link}]'
+                )
+            else:  # Normal [text|link] link
+                return text.replace(f'|{link.original_link}]', f'|{link.wiki_link}]')
+
+        elif link.link_type == RelativeLinkType.IMAGE:
+            if link.text == link.original_link:
+                # This means the JIRA markdown is simply !file.ext!
+                return text.replace(f'!{link.original_link}!', f'!{link.wiki_link}!')
+            else:
+                # Image with parameters, like !some_pic.png|alt=image!
+                return text.replace(f'!{link.original_link}|', f'!{link.wiki_link}|')
+
+        else:
+            logging.warning(
+                'Unexpected link type %s - returning text as is.', link.link_type
+            )
+            return text
+
+    def _attach_to_page(self, page_id: str, attachment_path: str) -> None:
+        _, attachment_name = os.path.split(attachment_path)
+
+        # TODO This doesn't handle the case of a doc file including two different
+        # images with the same file name (#23)
+        logging.debug('Looking for an attachment named %s', attachment_name)
+        attachments = self.wiki_client.get_attachments_from_content(
+            page_id, filename=attachment_name
+        )['results']
+
+        if attachments:
+            logging.debug('%s attachment(s) found', len(attachments))
+            # TODO Figure out whether we want to update the image (#24)
+            # The API doesn't tell us when the file was last updated, so we can't
+            # compare that to the last commit on that file
+        else:
+            logging.info('Attaching file %s to page %s', attachment_path, page_id)
+            self.wiki_client.attach_file(filename=attachment_path, page_id=page_id)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,8 +3,8 @@ End-to-end tests that make sure the correct Confluence pages are
 created/updated, and with the correct content
 """
 
-import tempfile
 import os
+import tempfile
 from unittest import mock
 
 import wiki_sync
@@ -29,13 +29,7 @@ def test_page_is_created_under_correct_root(mock_wiki, get_repo_root_mock):
 
         wiki_client = mock_wiki.return_value
         wiki_client.get_page_id.return_value = root_page_id
-
-        os.environ['GITHUB_REPOSITORY'] = 'owner/repo'
-        os.environ['INPUT_ROOT-PAGE-TITLE'] = root_page_title
-        os.environ['INPUT_SPACE-NAME'] = space_name
-        os.environ['INPUT_TOKEN'] = ''
-        os.environ['INPUT_USER'] = ''
-        os.environ['INPUT_WIKI-BASE-URL'] = ''
+        set_up_dummy_environment(space_name, root_page_title)
 
         wiki_sync.sync_files([file_name])
 
@@ -48,3 +42,116 @@ def test_page_is_created_under_correct_root(mock_wiki, get_repo_root_mock):
         assert kwargs['title'] == f'repo/{file_name}'
         assert file_contents in kwargs['body']
         assert kwargs['representation'] == 'wiki'
+
+
+@mock.patch('wiki_sync.get_repository_root')
+@mock.patch('atlassian.Confluence')
+def test_page_created_with_attached_image(mock_wiki, get_repo_root_mock):
+    """When a new file references an image, the wiki page needs to be created and the
+    image needs to be attached to it"""
+    file_path = 'hello.md'
+    attachment_name = 'some-image.jpg'
+    attachment_path = f'images/{attachment_name}'
+    file_contents = f'![A cool image]({attachment_path})'
+
+    with tempfile.TemporaryDirectory() as repo_root:
+        get_repo_root_mock.return_value = repo_root
+
+        file_abs_path = os.path.join(repo_root, file_path)
+        with open(file_abs_path, mode='w', encoding='utf-8') as file:
+            print(file_contents, file=file)
+
+        # The file isn't actually an image, but that's not important
+        os.makedirs(os.path.join(repo_root, 'images'))
+        attachment_abs_path = os.path.join(repo_root, attachment_path)
+        with open(attachment_abs_path, mode='w', encoding='utf-8') as attachment:
+            print('foobar', file=attachment)
+
+        root_page_id = 12345
+        doc_page_id = 67890
+        root_page_title = 'My docs'
+        space_name = 'SPACE'
+
+        wiki_client = mock_wiki.return_value
+        # Root page exists but doc page doesn't
+        wiki_client.get_page_id.side_effect = [root_page_id, None]
+        wiki_client.update_or_create.return_value = {'id': doc_page_id}
+        set_up_dummy_environment(space_name, root_page_title)
+
+        wiki_sync.sync_files([file_path])
+
+        wiki_client.get_page_id.assert_has_calls(
+            [
+                # First one to find the root, to create the new page under it
+                mock.call(space_name, root_page_title),
+                # Second one to check whether the page already exists, when looking at
+                # the image link
+                mock.call(space_name, f'repo/{file_path}'),
+            ]
+        )
+        wiki_client.update_or_create.assert_called_once()
+        wiki_client.attach_file.assert_called_once_with(
+            filename=attachment_path, page_id=doc_page_id
+        )
+
+
+@mock.patch('wiki_sync.get_repository_root')
+@mock.patch('atlassian.Confluence')
+def test_new_image_attachment_to_existing_page(mock_wiki, get_repo_root_mock):
+    """When an existing file starts referencing an image, the image needs to be attached
+    to the wiki page"""
+    file_path = 'hello.md'
+    attachment_name = 'some-image.jpg'
+    attachment_path = f'images/{attachment_name}'
+    file_contents = f'![A cool image]({attachment_path})'
+
+    with tempfile.TemporaryDirectory() as repo_root:
+        get_repo_root_mock.return_value = repo_root
+
+        file_abs_path = os.path.join(repo_root, file_path)
+        with open(file_abs_path, mode='w', encoding='utf-8') as file:
+            print(file_contents, file=file)
+
+        # The file isn't actually an image, but that's not important
+        os.makedirs(os.path.join(repo_root, 'images'))
+        attachment_abs_path = os.path.join(repo_root, attachment_path)
+        with open(attachment_abs_path, mode='w', encoding='utf-8') as attachment:
+            print('foobar', file=attachment)
+
+        root_page_id = 12345
+        doc_page_id = 67890
+        root_page_title = 'My docs'
+        space_name = 'SPACE'
+
+        wiki_client = mock_wiki.return_value
+        # Both root page and doc page exist
+        wiki_client.get_page_id.side_effect = [root_page_id, doc_page_id]
+        wiki_client.update_or_create.return_value = {'id': doc_page_id}
+        # No existing attachments on the doc page
+        wiki_client.get_attachments_from_content.return_value = {'results': []}
+        set_up_dummy_environment(space_name, root_page_title)
+
+        wiki_sync.sync_files([file_path])
+
+        wiki_client.get_page_id.assert_has_calls(
+            [
+                # First one to find the root, to create the new page under it
+                mock.call(space_name, root_page_title),
+                # Second one to check whether the page already exists, when looking at
+                # the image link
+                mock.call(space_name, f'repo/{file_path}'),
+            ]
+        )
+        wiki_client.update_or_create.assert_called_once()
+        wiki_client.attach_file.assert_called_once_with(
+            filename=attachment_path, page_id=doc_page_id
+        )
+
+
+def set_up_dummy_environment(space_name: str, root_page_title: str) -> None:
+    os.environ['GITHUB_REPOSITORY'] = 'owner/repo'
+    os.environ['INPUT_ROOT-PAGE-TITLE'] = root_page_title
+    os.environ['INPUT_SPACE-NAME'] = space_name
+    os.environ['INPUT_TOKEN'] = ''
+    os.environ['INPUT_USER'] = ''
+    os.environ['INPUT_WIKI-BASE-URL'] = ''


### PR DESCRIPTION
Closes #8, #19, #35

Re-run of #21

When a document references an image, the image gets attached to the wiki page.

Extracted a ContentConverter class, as the logic is starting to get complex there.

The images are currently not updated - see #24.