### PR TITLE
refactor: Remove get_repository_root()

### DIFF
--- a/content_converter.py
+++ b/content_converter.py
@@ -48,12 +48,10 @@ class ContentConverter:
     def __init__(
         self,
         wiki_client: atlassian.Confluence,
-        repo_root: str,
         gh_root: str,
         repo_name: str,
     ) -> str:
         self.wiki_client = wiki_client
-        self.repo_root = repo_root
         self.gh_root = gh_root
         self.repo_name = repo_name
 
@@ -62,8 +60,7 @@ class ContentConverter:
     def convert_file_contents(self, file_path: str) -> str:
         self.files_to_attach_to_last_page = []
 
-        absolute_file_path = os.path.join(self.repo_root, file_path)
-        formated_file_contents = pypandoc.convert_file(absolute_file_path, 'jira')
+        formated_file_contents = pypandoc.convert_file(file_path, 'jira')
 
         return self._replace_relative_links(file_path, formated_file_contents)
 
@@ -159,14 +156,10 @@ class ContentConverter:
                 continue
 
             # Find the absolute path of the target file
-            file_abs_path = os.path.join(self.repo_root, file_path)
-            file_abs_dir = os.path.dirname(file_abs_path)
-            target_abs_path = os.path.normpath(os.path.join(file_abs_dir, target))
-            if not os.path.exists(target_abs_path):  # Not actually a relative link
+            file_dir = os.path.dirname(file_path)
+            target_path = os.path.normpath(os.path.join(file_dir, target))
+            if not os.path.exists(target_path):  # Not actually a relative link
                 continue
-
-            # Now find the path from repo root to the target file
-            target_path = target_abs_path.removeprefix(self.repo_root).removeprefix('/')
 
             links.append(
                 RelativeLink(

--- a/tests/test_content_formatting.py
+++ b/tests/test_content_formatting.py
@@ -3,7 +3,6 @@
 e.g. relative links, escaping special JIRA strings"""
 
 import os
-import tempfile
 from unittest import mock
 
 import pytest
@@ -21,319 +20,293 @@ def setup_function():
 
 
 @pytest.fixture
+def use_temp_dir(tmp_path):
+    # tmp_path is the path to a pytest-provided temporary folder
+    # Run the test inside it, so the files it creates are cleaned up afterwards
+    os.chdir(tmp_path)
+    os.makedirs('foo/bar')
+    yield
+
+
+@pytest.fixture
 def wiki_mock():
     m = mock.Mock()
     m.get_page_by_title.return_value = None
     return m
 
 
-def test_http_link(wiki_mock):
-    with tempfile.TemporaryDirectory() as repo_root:
-        # Create the doc file with an HTTP link
-        doc_path = 'new_doc.md'
-        doc_abs_path = os.path.join(repo_root, doc_path)
-        with open(doc_abs_path, mode='w', encoding='utf-8') as doc_file:
-            print('Check out this [link](https://example.org)', file=doc_file)
+def test_http_link(use_temp_dir, wiki_mock):
+    # Create the doc file with an HTTP link
+    doc_path = 'new_doc.md'
+    with open(doc_path, mode='w', encoding='utf-8') as doc_file:
+        print('Check out this [link](https://example.org)', file=doc_file)
 
-        converter = ContentConverter(wiki_mock, repo_root, GH_ROOT, REPO_NAME)
-        output = converter.convert_file_contents(doc_path)
+    converter = ContentConverter(wiki_mock, GH_ROOT, REPO_NAME)
+    output = converter.convert_file_contents(doc_path)
 
-        assert output == 'Check out this [link|https://example.org]\n'
+    assert output == 'Check out this [link|https://example.org]\n'
 
 
-def test_link_to_file_both_in_root(wiki_mock):
-    with tempfile.TemporaryDirectory() as repo_root:
-        # Create a file that the doc will link to
-        linked_file_path = 'linked_file.py'
-        linked_file_abs_path = os.path.join(repo_root, linked_file_path)
-        write_something_to_file(linked_file_abs_path)
+def test_link_to_file_both_in_root(use_temp_dir, wiki_mock):
+    # Create a file that the doc will link to
+    linked_file_path = 'linked_file.py'
+    write_something_to_file(linked_file_path)
 
-        # Create the doc file with a link to the other one
-        doc_path = 'new_doc.md'
-        doc_abs_path = os.path.join(repo_root, doc_path)
-        with open(doc_abs_path, mode='w', encoding='utf-8') as doc_file:
-            contents = f'Check out this [other file]({linked_file_path})'
-            print(contents, file=doc_file)
+    # Create the doc file with a link to the other one
+    doc_path = 'new_doc.md'
+    with open(doc_path, mode='w', encoding='utf-8') as doc_file:
+        contents = f'Check out this [other file]({linked_file_path})'
+        print(contents, file=doc_file)
 
-        converter = ContentConverter(wiki_mock, repo_root, GH_ROOT, REPO_NAME)
-        output = converter.convert_file_contents(doc_path)
+    converter = ContentConverter(wiki_mock, GH_ROOT, REPO_NAME)
+    output = converter.convert_file_contents(doc_path)
 
-        expected_gh_link = f'{GH_ROOT}{linked_file_path}'
-        expected_output = f'Check out this [other file|{expected_gh_link}]\n'
-        assert output == expected_output
+    expected_gh_link = f'{GH_ROOT}{linked_file_path}'
+    expected_output = f'Check out this [other file|{expected_gh_link}]\n'
+    assert output == expected_output
 
 
-def test_link_to_file_in_same_non_root_folder(wiki_mock):
-    with tempfile.TemporaryDirectory() as repo_root:
-        os.makedirs(os.path.join(repo_root, 'foo'))
-        # Create a file that the doc will link to
-        linked_file_name = 'linked_file.py'
-        linked_file_path = os.path.join('foo', 'linked_file.py')
-        linked_file_abs_path = os.path.join(repo_root, linked_file_path)
-        write_something_to_file(linked_file_abs_path)
+def test_link_to_file_in_same_non_root_folder(use_temp_dir, wiki_mock):
+    # Create a file that the doc will link to
+    linked_file_name = 'linked_file.py'
+    linked_file_path = os.path.join('foo', 'linked_file.py')
+    write_something_to_file(linked_file_path)
 
-        # Create the doc file with a link to the other one
-        doc_path = os.path.join('foo', 'new_doc.md')
-        doc_abs_path = os.path.join(repo_root, doc_path)
-        with open(doc_abs_path, mode='w', encoding='utf-8') as doc_file:
-            contents = f'Check out this [other file]({linked_file_name})'
-            print(contents, file=doc_file)
+    # Create the doc file with a link to the other one
+    doc_path = os.path.join('foo', 'new_doc.md')
+    with open(doc_path, mode='w', encoding='utf-8') as doc_file:
+        contents = f'Check out this [other file]({linked_file_name})'
+        print(contents, file=doc_file)
 
-        converter = ContentConverter(wiki_mock, repo_root, GH_ROOT, REPO_NAME)
-        output = converter.convert_file_contents(doc_path)
+    converter = ContentConverter(wiki_mock, GH_ROOT, REPO_NAME)
+    output = converter.convert_file_contents(doc_path)
 
-        expected_gh_link = f'{GH_ROOT}{linked_file_path}'
-        expected_output = f'Check out this [other file|{expected_gh_link}]\n'
-        assert output == expected_output
+    expected_gh_link = f'{GH_ROOT}{linked_file_path}'
+    expected_output = f'Check out this [other file|{expected_gh_link}]\n'
+    assert output == expected_output
 
 
-def test_link_to_file_in_child_folder(wiki_mock):
-    with tempfile.TemporaryDirectory() as repo_root:
-        # Create a file that the doc will link to (in a subfolder)
-        os.makedirs(os.path.join(repo_root, 'foo', 'bar'))
-        linked_doc_path = os.path.join('foo', 'bar', 'linked_file.py')
-        linked_doc_abs_path = os.path.join(repo_root, linked_doc_path)
-        write_something_to_file(linked_doc_abs_path)
+def test_link_to_file_in_child_folder(use_temp_dir, wiki_mock):
+    # Create a file that the doc will link to (in a subfolder)
+    linked_doc_path = os.path.join('foo', 'bar', 'linked_file.py')
+    write_something_to_file(linked_doc_path)
 
-        # Create the doc file with a link to the other one
-        doc_path = 'new_doc.md'
-        doc_abs_path = os.path.join(repo_root, doc_path)
-        with open(doc_abs_path, mode='w', encoding='utf-8') as doc_file:
-            contents = f'Check out this [other file]({linked_doc_path})'
-            print(contents, file=doc_file)
+    # Create the doc file with a link to the other one
+    doc_path = 'new_doc.md'
+    with open(doc_path, mode='w', encoding='utf-8') as doc_file:
+        contents = f'Check out this [other file]({linked_doc_path})'
+        print(contents, file=doc_file)
 
-        converter = ContentConverter(wiki_mock, repo_root, GH_ROOT, REPO_NAME)
-        output = converter.convert_file_contents(doc_path)
+    converter = ContentConverter(wiki_mock, GH_ROOT, REPO_NAME)
+    output = converter.convert_file_contents(doc_path)
 
-        expected_gh_link = f'{GH_ROOT}{linked_doc_path}'
-        expected_output = f'Check out this [other file|{expected_gh_link}]\n'
-        assert output == expected_output
+    expected_gh_link = f'{GH_ROOT}{linked_doc_path}'
+    expected_output = f'Check out this [other file|{expected_gh_link}]\n'
+    assert output == expected_output
 
 
-def test_link_to_file_in_parent_folder(wiki_mock):
-    with tempfile.TemporaryDirectory() as repo_root:
-        # Create a file that the doc will link to
-        linked_doc_path = 'linked_file.py'
-        linked_doc_abs_path = os.path.join(repo_root, linked_doc_path)
-        write_something_to_file(linked_doc_abs_path)
+def test_link_to_file_in_parent_folder(use_temp_dir, wiki_mock):
+    # Create a file that the doc will link to
+    linked_doc_path = 'linked_file.py'
+    write_something_to_file(linked_doc_path)
 
-        # Create the doc file in a subfolder, with a link to the other one
-        os.makedirs(os.path.join(repo_root, 'foo', 'bar'))
-        doc_path = os.path.join('foo', 'bar', 'new_doc.md')
-        doc_abs_path = os.path.join(repo_root, doc_path)
-        with open(doc_abs_path, mode='w', encoding='utf-8') as doc_file:
-            contents = 'Check out this [other file](../../linked_file.py)'
-            print(contents, file=doc_file)
+    # Create the doc file in a subfolder, with a link to the other one
+    doc_path = os.path.join('foo', 'bar', 'new_doc.md')
+    with open(doc_path, mode='w', encoding='utf-8') as doc_file:
+        contents = 'Check out this [other file](../../linked_file.py)'
+        print(contents, file=doc_file)
 
-        converter = ContentConverter(wiki_mock, repo_root, GH_ROOT, REPO_NAME)
-        output = converter.convert_file_contents(doc_path)
+    converter = ContentConverter(wiki_mock, GH_ROOT, REPO_NAME)
+    output = converter.convert_file_contents(doc_path)
 
-        expected_gh_link = f'{GH_ROOT}linked_file.py'
-        expected_output = f'Check out this [other file|{expected_gh_link}]\n'
-        assert output == expected_output
+    expected_gh_link = f'{GH_ROOT}linked_file.py'
+    expected_output = f'Check out this [other file|{expected_gh_link}]\n'
+    assert output == expected_output
 
 
-def test_simplified_link(wiki_mock):
-    # Link where the name of the link is the same as the link itself
-    with tempfile.TemporaryDirectory() as repo_root:
-        # Create a file that the doc will link to
-        linked_doc_path = 'linked_file.py'
-        linked_doc_abs_path = os.path.join(repo_root, linked_doc_path)
-        write_something_to_file(linked_doc_abs_path)
+def test_simplified_link(use_temp_dir, wiki_mock):
+    """Link where the name of the link is the same as the link itself"""
+    # Create a file that the doc will link to
+    linked_doc_path = 'linked_file.py'
+    write_something_to_file(linked_doc_path)
 
-        # Create the doc file with a link to the other one
-        doc_path = 'new_doc.md'
-        doc_abs_path = os.path.join(repo_root, doc_path)
-        with open(doc_abs_path, mode='w', encoding='utf-8') as doc_file:
-            contents = f'Check out [{linked_doc_path}]({linked_doc_path})'
-            print(contents, file=doc_file)
+    # Create the doc file with a link to the other one
+    doc_path = 'new_doc.md'
+    with open(doc_path, mode='w', encoding='utf-8') as doc_file:
+        contents = f'Check out [{linked_doc_path}]({linked_doc_path})'
+        print(contents, file=doc_file)
 
-        converter = ContentConverter(wiki_mock, repo_root, GH_ROOT, REPO_NAME)
-        output = converter.convert_file_contents(doc_path)
+    converter = ContentConverter(wiki_mock, GH_ROOT, REPO_NAME)
+    output = converter.convert_file_contents(doc_path)
 
-        expected_link = f'[{linked_doc_path}|{GH_ROOT}{linked_doc_path}]'
-        assert output == f'Check out {expected_link}\n'
+    expected_link = f'[{linked_doc_path}|{GH_ROOT}{linked_doc_path}]'
+    assert output == f'Check out {expected_link}\n'
 
 
-def test_link_to_non_existing_file(wiki_mock):
-    with tempfile.TemporaryDirectory() as repo_root:
-        # Create the doc file with a link to a non-existing file
-        doc_path = 'new_doc.md'
-        doc_abs_path = os.path.join(repo_root, doc_path)
-        with open(doc_abs_path, mode='w', encoding='utf-8') as doc_file:
-            contents = 'Check out this [other file](non_existing.py)'
-            print(contents, file=doc_file)
+def test_link_to_non_existing_file(use_temp_dir, wiki_mock):
+    # Create the doc file with a link to a non-existing file
+    doc_path = 'new_doc.md'
+    with open(doc_path, mode='w', encoding='utf-8') as doc_file:
+        contents = 'Check out this [other file](non_existing.py)'
+        print(contents, file=doc_file)
 
-        converter = ContentConverter(wiki_mock, repo_root, GH_ROOT, REPO_NAME)
-        output = converter.convert_file_contents(doc_path)
+    converter = ContentConverter(wiki_mock, GH_ROOT, REPO_NAME)
+    output = converter.convert_file_contents(doc_path)
 
-        # Output is the same
-        assert output == 'Check out this [other file|non_existing.py]\n'
+    # Output is the same
+    assert output == 'Check out this [other file|non_existing.py]\n'
 
 
-def test_link_to_file_that_exists_on_confluence(wiki_mock):
+def test_link_to_file_that_exists_on_confluence(use_temp_dir, wiki_mock):
     space = 'WikiSpace'
     os.environ['INPUT_SPACE-NAME'] = space
     wiki_url = 'http://mywiki.atlassian.net'
     os.environ['INPUT_WIKI-BASE-URL'] = wiki_url
 
-    with tempfile.TemporaryDirectory() as repo_root:
-        # Create a file that the doc will link to
-        linked_file_name = 'linked_file.py'
-        linked_doc_path = os.path.join(repo_root, linked_file_name)
-        write_something_to_file(linked_doc_path)
+    # Create a file that the doc will link to
+    linked_file_name = 'linked_file.py'
+    write_something_to_file(linked_file_name)
 
-        # When the wiki client wants to know whether the linked file has an
-        # existing Confluence page, say yes
-        wiki_mock.get_page_by_title.return_value = {
-            '_links': {'webui': f'/spaces/{space}/pages/123'}
-        }
+    # When the wiki client wants to know whether the linked file has an
+    # existing Confluence page, say yes
+    wiki_mock.get_page_by_title.return_value = {
+        '_links': {'webui': f'/spaces/{space}/pages/123'}
+    }
 
-        # Create the doc file with a link to the other one
-        doc_path = os.path.join(repo_root, 'new_doc.md')
-        with open(doc_path, mode='w', encoding='utf-8') as doc_file:
-            contents = f'Check out this [other file]({linked_file_name})'
-            print(contents, file=doc_file)
+    # Create the doc file with a link to the other one
+    doc_path = 'new_doc.md'
+    with open(doc_path, mode='w', encoding='utf-8') as doc_file:
+        contents = f'Check out this [other file]({linked_file_name})'
+        print(contents, file=doc_file)
 
-        converter = ContentConverter(wiki_mock, repo_root, GH_ROOT, REPO_NAME)
-        output = converter.convert_file_contents(doc_path)
+    converter = ContentConverter(wiki_mock, GH_ROOT, REPO_NAME)
+    output = converter.convert_file_contents(doc_path)
 
-        wiki_link = f'{wiki_url}/wiki/spaces/{space}/pages/123'
-        expected_output = f'Check out this [other file|{wiki_link}]\n'
-        assert output == expected_output
+    wiki_link = f'{wiki_url}/wiki/spaces/{space}/pages/123'
+    expected_output = f'Check out this [other file|{wiki_link}]\n'
+    assert output == expected_output
 
-        wiki_mock.get_page_by_title.assert_called_once_with(
-            space, f'{REPO_NAME}/linked_file.py'
+    wiki_mock.get_page_by_title.assert_called_once_with(
+        space, f'{REPO_NAME}/linked_file.py'
+    )
+
+
+def test_several_links_on_same_line(use_temp_dir, wiki_mock):
+    # Create file that the doc will link to
+    linked_file_name = 'linked_file.py'
+    write_something_to_file(linked_file_name)
+    linked_file_name_2 = 'linked_file_2.go'
+    write_something_to_file(linked_file_name_2)
+
+    # Create the doc file with a link to the other one
+    doc_path = 'new_doc.md'
+    with open(doc_path, mode='w', encoding='utf-8') as doc_file:
+        contents = (
+            f'Check out this [file]({linked_file_name})'
+            f' and also [that one]({linked_file_name_2})'
         )
+        print(contents, file=doc_file)
+
+    converter = ContentConverter(wiki_mock, GH_ROOT, REPO_NAME)
+    output = converter.convert_file_contents(doc_path)
+
+    expected_gh_links = [
+        f'{GH_ROOT}{linked_file_name}',
+        f'{GH_ROOT}{linked_file_name_2}',
+    ]
+    expected_output = (
+        f'Check out this [file|{expected_gh_links[0]}] and'
+        f' also [that one|{expected_gh_links[1]}]\n'
+    )
+    assert output == expected_output
 
 
-def test_several_links_on_same_line(wiki_mock):
-    with tempfile.TemporaryDirectory() as repo_root:
-        # Create file that the doc will link to
-        linked_file_name = 'linked_file.py'
-        write_something_to_file(os.path.join(repo_root, linked_file_name))
-        linked_file_name_2 = 'linked_file_2.go'
-        write_something_to_file(os.path.join(repo_root, linked_file_name_2))
+def test_simple_link_to_image(use_temp_dir, wiki_mock):
+    # Create an image that the doc will link to (in a subfolder)
+    linked_doc_path = os.path.join('foo', 'bar', 'cool_image.png')
+    # The file isn't actually an image, but that's not important
+    write_something_to_file(linked_doc_path)
 
-        # Create the doc file with a link to the other one
-        doc_path = 'new_doc.md'
-        doc_abs_path = os.path.join(repo_root, doc_path)
-        with open(doc_abs_path, mode='w', encoding='utf-8') as doc_file:
-            contents = (
-                f'Check out this [file]({linked_file_name})'
-                f' and also [that one]({linked_file_name_2})'
-            )
-            print(contents, file=doc_file)
+    # The wiki page doesn't have any attachments
+    wiki_mock.get_attachments_from_content.return_value = {'results': []}
 
-        converter = ContentConverter(wiki_mock, repo_root, GH_ROOT, REPO_NAME)
-        output = converter.convert_file_contents(doc_path)
+    # Create the doc file with a link to the other one
+    doc_path = 'new_doc.md'
+    with open(doc_path, mode='w', encoding='utf-8') as doc_file:
+        contents = f'Check out ![]({linked_doc_path})'
+        print(contents, file=doc_file)
 
-        expected_gh_links = [
-            f'{GH_ROOT}{linked_file_name}',
-            f'{GH_ROOT}{linked_file_name_2}',
-        ]
-        expected_output = (
-            f'Check out this [file|{expected_gh_links[0]}] and'
-            f' also [that one|{expected_gh_links[1]}]\n'
-        )
-        assert output == expected_output
+    converter = ContentConverter(wiki_mock, GH_ROOT, REPO_NAME)
+    output = converter.convert_file_contents(doc_path)
+
+    # Even though the image isn't in the same folder as the document, the
+    # name of the image attached to the wiki page is just the file name
+    assert output == 'Check out !cool_image.png!\n'
+
+    wiki_mock.attach_file.assert_called_once()
 
 
-def test_simple_link_to_image(wiki_mock):
-    with tempfile.TemporaryDirectory() as repo_root:
-        # Create an image that the doc will link to (in a subfolder)
-        os.makedirs(os.path.join(repo_root, 'foo', 'bar'))
-        linked_doc_path = os.path.join('foo', 'bar', 'cool_image.png')
-        linked_doc_abs_path = os.path.join(repo_root, linked_doc_path)
-        # The file isn't actually an image, but that's not important
-        write_something_to_file(linked_doc_abs_path)
-
-        # The wiki page doesn't have any attachments
-        wiki_mock.get_attachments_from_content.return_value = {'results': []}
-
-        # Create the doc file with a link to the other one
-        doc_path = os.path.join(repo_root, 'new_doc.md')
-        with open(doc_path, mode='w', encoding='utf-8') as doc_file:
-            contents = f'Check out ![]({linked_doc_path})'
-            print(contents, file=doc_file)
-
-        converter = ContentConverter(wiki_mock, repo_root, GH_ROOT, REPO_NAME)
-        output = converter.convert_file_contents(doc_path)
-
-        # Even though the image isn't in the same folder as the document, the
-        # name of the image attached to the wiki page is just the file name
-        assert output == 'Check out !cool_image.png!\n'
-
-        wiki_mock.attach_file.assert_called_once()
-
-
-def test_simple_link_to_image_new_page(wiki_mock):
+def test_simple_link_to_image_new_page(use_temp_dir, wiki_mock):
     """Same as the previous one, but the wiki page didn't already exist"""
-    with tempfile.TemporaryDirectory() as repo_root:
-        # Create an image that the doc will link to (in a subfolder)
-        os.makedirs(os.path.join(repo_root, 'foo', 'bar'))
-        linked_doc_path = os.path.join('foo', 'bar', 'cool_image.png')
-        linked_doc_abs_path = os.path.join(repo_root, linked_doc_path)
-        # The file isn't actually an image, but that's not important
-        write_something_to_file(linked_doc_abs_path)
+    # Create an image that the doc will link to (in a subfolder)
+    linked_doc_path = os.path.join('foo', 'bar', 'cool_image.png')
+    # The file isn't actually an image, but that's not important
+    write_something_to_file(linked_doc_path)
 
-        # The wiki page doesn't exist
-        wiki_mock.get_page_id.return_value = None
+    # The wiki page doesn't exist
+    wiki_mock.get_page_id.return_value = None
 
-        # Create the doc file with a link to the other one
-        doc_path = os.path.join(repo_root, 'new_doc.md')
-        with open(doc_path, mode='w', encoding='utf-8') as doc_file:
-            contents = f'Check out ![]({linked_doc_path})'
-            print(contents, file=doc_file)
+    # Create the doc file with a link to the other one
+    doc_path = 'new_doc.md'
+    with open(doc_path, mode='w', encoding='utf-8') as doc_file:
+        contents = f'Check out ![]({linked_doc_path})'
+        print(contents, file=doc_file)
 
-        converter = ContentConverter(wiki_mock, repo_root, GH_ROOT, REPO_NAME)
-        output = converter.convert_file_contents(doc_path)
+    converter = ContentConverter(wiki_mock, GH_ROOT, REPO_NAME)
+    output = converter.convert_file_contents(doc_path)
 
-        # Even though the image isn't in the same folder as the document, the
-        # name of the image attached to the wiki page is just the file name
-        assert output == 'Check out !cool_image.png!\n'
+    # Even though the image isn't in the same folder as the document, the
+    # name of the image attached to the wiki page is just the file name
+    assert output == 'Check out !cool_image.png!\n'
 
-        # File wasn't attached during content conversion, because the wiki page doesn't
-        # exist at that time.
-        wiki_mock.attach_file.assert_not_called()
-        # Remember the information of the file to be attached
-        assert converter.files_to_attach_to_last_page == [linked_doc_path]
+    # File wasn't attached during content conversion, because the wiki page doesn't
+    # exist at that time.
+    wiki_mock.attach_file.assert_not_called()
+    # Remember the information of the file to be attached
+    assert converter.files_to_attach_to_last_page == [linked_doc_path]
 
 
-def test_link_to_image_with_params(wiki_mock):
-    with tempfile.TemporaryDirectory() as repo_root:
-        # Create an image that the doc will link to
-        linked_doc_path = 'cool_image.png'
-        linked_doc_abs_path = os.path.join(repo_root, linked_doc_path)
-        # The file isn't actually an image, but that's not important
-        write_something_to_file(linked_doc_abs_path)
+def test_link_to_image_with_params(use_temp_dir, wiki_mock):
+    # Create an image that the doc will link to
+    linked_doc_path = 'cool_image.png'
+    # The file isn't actually an image, but that's not important
+    write_something_to_file(linked_doc_path)
 
-        # The wiki page doesn't have any attachments
-        wiki_mock.get_attachments_from_content.return_value = {'results': []}
+    # The wiki page doesn't have any attachments
+    wiki_mock.get_attachments_from_content.return_value = {'results': []}
 
-        # Create the doc file with a link to the other one
-        doc_path = os.path.join(repo_root, 'new_doc.md')
-        with open(doc_path, mode='w', encoding='utf-8') as doc_file:
-            contents = f'Check out ![Cool image]({linked_doc_path})'
-            print(contents, file=doc_file)
+    # Create the doc file with a link to the other one
+    doc_path = 'new_doc.md'
+    with open(doc_path, mode='w', encoding='utf-8') as doc_file:
+        contents = f'Check out ![Cool image]({linked_doc_path})'
+        print(contents, file=doc_file)
 
-        converter = ContentConverter(wiki_mock, repo_root, GH_ROOT, REPO_NAME)
-        output = converter.convert_file_contents(doc_path)
+    converter = ContentConverter(wiki_mock, GH_ROOT, REPO_NAME)
+    output = converter.convert_file_contents(doc_path)
 
-        assert output == f'Check out !{linked_doc_path}|alt=Cool image!\n'
-        wiki_mock.attach_file.assert_called_once()
+    assert output == f'Check out !{linked_doc_path}|alt=Cool image!\n'
+    wiki_mock.attach_file.assert_called_once()
 
 
-def test_jira_macro():
-    with tempfile.TemporaryDirectory() as repo_root:
-        doc_path = os.path.join(repo_root, 'new_doc.md')
-        with open(doc_path, mode='w', encoding='utf-8') as doc_file:
-            print('Bash example using ${SOME_VARIABLE}', file=doc_file)
+def test_jira_macro(use_temp_dir):
+    doc_path = 'new_doc.md'
+    with open(doc_path, mode='w', encoding='utf-8') as doc_file:
+        print('Bash example using ${SOME_VARIABLE}', file=doc_file)
 
-        converter = ContentConverter(wiki_mock, repo_root, GH_ROOT, REPO_NAME)
-        output = converter.convert_file_contents(doc_path)
+    converter = ContentConverter(wiki_mock, GH_ROOT, REPO_NAME)
+    output = converter.convert_file_contents(doc_path)
 
-        assert output == r'Bash example using $\{SOME_VARIABLE\}' + '\n'
+    assert output == r'Bash example using $\{SOME_VARIABLE\}' + '\n'
 
 
 def write_something_to_file(file_path: str) -> None:

--- a/tests/test_file_filtering.py
+++ b/tests/test_file_filtering.py
@@ -8,7 +8,7 @@ import wiki_sync
 def test_no_ignored_folder():
     os.environ['INPUT_IGNORED-FOLDERS'] = ''
 
-    # MD and RST files should be synched
+    # MD and RST files should be synced
     assert wiki_sync.should_sync_file('file.md')
     assert wiki_sync.should_sync_file('file.rst')
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4,49 +4,56 @@ created/updated, and with the correct content
 """
 
 import os
-import tempfile
 from unittest import mock
+
+import pytest
 
 import wiki_sync
 
 
-@mock.patch('wiki_sync.get_repository_root')
-@mock.patch('atlassian.Confluence')
-def test_page_is_created_under_correct_root(mock_wiki, get_repo_root_mock):
+@pytest.fixture
+def use_temp_dir(tmp_path):
+    # tmp_path is the path to a pytest-provided temporary folder
+    # Run the test inside it, so the files it creates are cleaned up afterwards
+    os.chdir(tmp_path)
+    os.makedirs('foo/bar')
+    yield
+
+
+@pytest.fixture
+def wiki_mock():
+    with mock.patch('atlassian.Confluence') as mock_confluence:
+        yield mock_confluence.return_value
+
+
+def test_page_is_created_under_correct_root(use_temp_dir, wiki_mock):
     file_name = 'hello.md'
     file_contents = 'Hello, World'
 
-    with tempfile.TemporaryDirectory() as repo_root:
-        get_repo_root_mock.return_value = repo_root
+    with open(file_name, mode='w', encoding='utf-8') as doc_file:
+        print(file_contents, file=doc_file)
 
-        doc_file_path = os.path.join(repo_root, file_name)
-        with open(doc_file_path, mode='w', encoding='utf-8') as doc_file:
-            print(file_contents, file=doc_file)
+    root_page_id = 12345
+    root_page_title = 'My docs'
+    space_name = 'SPACE'
 
-        root_page_id = 12345
-        root_page_title = 'My docs'
-        space_name = 'SPACE'
+    wiki_mock.get_page_id.return_value = root_page_id
+    set_up_dummy_environment(space_name, root_page_title)
 
-        wiki_client = mock_wiki.return_value
-        wiki_client.get_page_id.return_value = root_page_id
-        set_up_dummy_environment(space_name, root_page_title)
+    wiki_sync.sync_files([file_name])
 
-        wiki_sync.sync_files([file_name])
+    wiki_mock.get_page_id.assert_called_once_with(space_name, root_page_title)
 
-        wiki_client.get_page_id.assert_called_once_with(space_name, root_page_title)
-
-        call_args_list = wiki_client.update_or_create.call_args_list
-        assert len(call_args_list) == 1
-        kwargs = call_args_list[0].kwargs
-        assert kwargs['parent_id'] == root_page_id
-        assert kwargs['title'] == f'repo/{file_name}'
-        assert file_contents in kwargs['body']
-        assert kwargs['representation'] == 'wiki'
+    call_args_list = wiki_mock.update_or_create.call_args_list
+    assert len(call_args_list) == 1
+    kwargs = call_args_list[0].kwargs
+    assert kwargs['parent_id'] == root_page_id
+    assert kwargs['title'] == f'repo/{file_name}'
+    assert file_contents in kwargs['body']
+    assert kwargs['representation'] == 'wiki'
 
 
-@mock.patch('wiki_sync.get_repository_root')
-@mock.patch('atlassian.Confluence')
-def test_page_created_with_attached_image(mock_wiki, get_repo_root_mock):
+def test_page_created_with_attached_image(use_temp_dir, wiki_mock):
     """When a new file references an image, the wiki page needs to be created and the
     image needs to be attached to it"""
     file_path = 'hello.md'
@@ -54,50 +61,42 @@ def test_page_created_with_attached_image(mock_wiki, get_repo_root_mock):
     attachment_path = f'images/{attachment_name}'
     file_contents = f'![A cool image]({attachment_path})'
 
-    with tempfile.TemporaryDirectory() as repo_root:
-        get_repo_root_mock.return_value = repo_root
+    with open(file_path, mode='w', encoding='utf-8') as file:
+        print(file_contents, file=file)
 
-        file_abs_path = os.path.join(repo_root, file_path)
-        with open(file_abs_path, mode='w', encoding='utf-8') as file:
-            print(file_contents, file=file)
+    # The file isn't actually an image, but that's not important
+    os.makedirs('images', exist_ok=True)
+    with open(attachment_path, mode='w', encoding='utf-8') as attachment:
+        print('foobar', file=attachment)
 
-        # The file isn't actually an image, but that's not important
-        os.makedirs(os.path.join(repo_root, 'images'))
-        attachment_abs_path = os.path.join(repo_root, attachment_path)
-        with open(attachment_abs_path, mode='w', encoding='utf-8') as attachment:
-            print('foobar', file=attachment)
+    root_page_id = 12345
+    doc_page_id = 67890
+    root_page_title = 'My docs'
+    space_name = 'SPACE'
 
-        root_page_id = 12345
-        doc_page_id = 67890
-        root_page_title = 'My docs'
-        space_name = 'SPACE'
+    # Root page exists but doc page doesn't
+    wiki_mock.get_page_id.side_effect = [root_page_id, None]
+    wiki_mock.update_or_create.return_value = {'id': doc_page_id}
+    set_up_dummy_environment(space_name, root_page_title)
 
-        wiki_client = mock_wiki.return_value
-        # Root page exists but doc page doesn't
-        wiki_client.get_page_id.side_effect = [root_page_id, None]
-        wiki_client.update_or_create.return_value = {'id': doc_page_id}
-        set_up_dummy_environment(space_name, root_page_title)
+    wiki_sync.sync_files([file_path])
 
-        wiki_sync.sync_files([file_path])
-
-        wiki_client.get_page_id.assert_has_calls(
-            [
-                # First one to find the root, to create the new page under it
-                mock.call(space_name, root_page_title),
-                # Second one to check whether the page already exists, when looking at
-                # the image link
-                mock.call(space_name, f'repo/{file_path}'),
-            ]
-        )
-        wiki_client.update_or_create.assert_called_once()
-        wiki_client.attach_file.assert_called_once_with(
-            filename=attachment_path, page_id=doc_page_id
-        )
+    wiki_mock.get_page_id.assert_has_calls(
+        [
+            # First one to find the root, to create the new page under it
+            mock.call(space_name, root_page_title),
+            # Second one to check whether the page already exists, when looking at
+            # the image link
+            mock.call(space_name, f'repo/{file_path}'),
+        ]
+    )
+    wiki_mock.update_or_create.assert_called_once()
+    wiki_mock.attach_file.assert_called_once_with(
+        filename=attachment_path, page_id=doc_page_id
+    )
 
 
-@mock.patch('wiki_sync.get_repository_root')
-@mock.patch('atlassian.Confluence')
-def test_new_image_attachment_to_existing_page(mock_wiki, get_repo_root_mock):
+def test_new_image_attachment_to_existing_page(use_temp_dir, wiki_mock):
     """When an existing file starts referencing an image, the image needs to be attached
     to the wiki page"""
     file_path = 'hello.md'
@@ -105,47 +104,41 @@ def test_new_image_attachment_to_existing_page(mock_wiki, get_repo_root_mock):
     attachment_path = f'images/{attachment_name}'
     file_contents = f'![A cool image]({attachment_path})'
 
-    with tempfile.TemporaryDirectory() as repo_root:
-        get_repo_root_mock.return_value = repo_root
+    with open(file_path, mode='w', encoding='utf-8') as file:
+        print(file_contents, file=file)
 
-        file_abs_path = os.path.join(repo_root, file_path)
-        with open(file_abs_path, mode='w', encoding='utf-8') as file:
-            print(file_contents, file=file)
+    # The file isn't actually an image, but that's not important
+    os.makedirs('images', exist_ok=True)
+    with open(attachment_path, mode='w', encoding='utf-8') as attachment:
+        print('foobar', file=attachment)
 
-        # The file isn't actually an image, but that's not important
-        os.makedirs(os.path.join(repo_root, 'images'))
-        attachment_abs_path = os.path.join(repo_root, attachment_path)
-        with open(attachment_abs_path, mode='w', encoding='utf-8') as attachment:
-            print('foobar', file=attachment)
+    root_page_id = 12345
+    doc_page_id = 67890
+    root_page_title = 'My docs'
+    space_name = 'SPACE'
 
-        root_page_id = 12345
-        doc_page_id = 67890
-        root_page_title = 'My docs'
-        space_name = 'SPACE'
+    # Both root page and doc page exist
+    wiki_mock.get_page_id.side_effect = [root_page_id, doc_page_id]
+    wiki_mock.update_or_create.return_value = {'id': doc_page_id}
+    # No existing attachments on the doc page
+    wiki_mock.get_attachments_from_content.return_value = {'results': []}
+    set_up_dummy_environment(space_name, root_page_title)
 
-        wiki_client = mock_wiki.return_value
-        # Both root page and doc page exist
-        wiki_client.get_page_id.side_effect = [root_page_id, doc_page_id]
-        wiki_client.update_or_create.return_value = {'id': doc_page_id}
-        # No existing attachments on the doc page
-        wiki_client.get_attachments_from_content.return_value = {'results': []}
-        set_up_dummy_environment(space_name, root_page_title)
+    wiki_sync.sync_files([file_path])
 
-        wiki_sync.sync_files([file_path])
-
-        wiki_client.get_page_id.assert_has_calls(
-            [
-                # First one to find the root, to create the new page under it
-                mock.call(space_name, root_page_title),
-                # Second one to check whether the page already exists, when looking at
-                # the image link
-                mock.call(space_name, f'repo/{file_path}'),
-            ]
-        )
-        wiki_client.update_or_create.assert_called_once()
-        wiki_client.attach_file.assert_called_once_with(
-            filename=attachment_path, page_id=doc_page_id
-        )
+    wiki_mock.get_page_id.assert_has_calls(
+        [
+            # First one to find the root, to create the new page under it
+            mock.call(space_name, root_page_title),
+            # Second one to check whether the page already exists, when looking at
+            # the image link
+            mock.call(space_name, f'repo/{file_path}'),
+        ]
+    )
+    wiki_mock.update_or_create.assert_called_once()
+    wiki_mock.attach_file.assert_called_once_with(
+        filename=attachment_path, page_id=doc_page_id
+    )
 
 
 def set_up_dummy_environment(space_name: str, root_page_title: str) -> None:


### PR DESCRIPTION
Closes #22

`get_repository_root()` has been returning an empty string and logging a warning since d9c1e332.

Removing it simplifies the code a bit, since the script now lives at the root of the repo.