### PR TITLE
feat: Add param for default branch

### DIFF
--- a/MAINTAINING.rst
+++ b/MAINTAINING.rst
@@ -14,8 +14,8 @@ version (whatever that means to the maintainer).
 
 When you've decided that this has happened, pick a version number. We use
 `Semantic Versioning <https://semver.org/>`_. For the purpose of this script,
-an incompatible API change is either removing an entry from ``action.yml``, or
-adding a required one.
+an incompatible API change is either removing an entry from ``action.yml``,
+adding a required one, or changing the default value of an optional one.
 
 Make sure all the tests pass on main.
 

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,10 @@ branding:
   icon: upload-cloud
   color: purple
 inputs:
+  default-git-branch:
+    description: The git branch that will be used for links to GitHub
+    required: false
+    default: 'HEAD'
   ignored-folders:
     description: Space-delimited list of folders to ignore when considering which files to upload
     required: false

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -143,6 +143,7 @@ def test_new_image_attachment_to_existing_page(use_temp_dir, wiki_mock):
 
 def set_up_dummy_environment(space_name: str, root_page_title: str) -> None:
     os.environ['GITHUB_REPOSITORY'] = 'owner/repo'
+    os.environ['INPUT_DEFAULT-GIT-BRANCH'] = 'main'
     os.environ['INPUT_ROOT-PAGE-TITLE'] = root_page_title
     os.environ['INPUT_SPACE-NAME'] = space_name
     os.environ['INPUT_TOKEN'] = ''

--- a/wiki_sync.py
+++ b/wiki_sync.py
@@ -64,11 +64,10 @@ def sync_files(files: list[str]) -> bool:
     logging.debug('The base root ID is %s', root_page_id)
 
     github_repo = os.environ['GITHUB_REPOSITORY']  # eg. 'octocat/Hello-World'
-    # TODO consider getting the name of the default branch and using that
-    # instead of HEAD
-    # Could be an optional parameter in action.yml
-    url_root_for_file = f'https://github.com/{github_repo}/blob/HEAD/'
     repo_name = github_repo.split('/')[1]
+
+    default_git_branch = os.environ['INPUT_DEFAULT-GIT-BRANCH']
+    url_root_for_file = f'https://github.com/{github_repo}/blob/{default_git_branch}/'
 
     converter = content_converter.ContentConverter(
         wiki_client, url_root_for_file, repo_name


### PR DESCRIPTION
Closes #71

Add an optional param for the default git branch, to be used in GitHub links. Defaults to "HEAD", which is what is currently used.