### PR TITLE
docs: Add note about tags for major versions

### DIFF
--- a/MAINTAINING.rst
+++ b/MAINTAINING.rst
@@ -43,3 +43,24 @@ Lastly, move the corresponding major release branch to the tag you just
 created. For example, if you created the ``v1.2`` tag, move the ``v1`` branch
 to point to the same commit. This allows clients to follow v1 and automatically
 get backward-compatible improvements.
+
+
+About tags for major versions
+=============================
+
+For major version changes, prefer using ``v2.0`` over ``v2`` as the tag. git
+doesn't like it when a tag and a branch have the same name.
+
+If there is a tag with the same name as the release branch, git will complain
+when you try to push the branch. Just use the full name of the branch:
+
+.. code-block:: bash
+
+    $ git push origin v2
+    error: src refspec v2 matches more than one
+    error: failed to push some refs to 'github.com:talkiq/confluence-wiki-sync.git'
+
+    $ git push origin refs/heads/v2:refs/heads/v2
+    Total 0 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
+    To github.com:talkiq/confluence-wiki-sync.git
+        6418101..4671ac9  v2 -> v2


### PR DESCRIPTION
We have a v2 tag and a v2 branch, which makes the release slightly more annoying. Document that we should avoid that situation, and how to deal with it when it's too late.