### PR TITLE
feat: add option to disable read-only warning banner

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,10 @@ branding:
   icon: upload-cloud
   color: purple
 inputs:
+  add-warning-banner:
+    description: Add a read-only warning banner to synced pages
+    required: false
+    default: 'true'
   default-git-branch:
     description: The git branch that will be used for links to GitHub
     required: false
@@ -12,10 +16,6 @@ inputs:
     description: Space-delimited list of folders to ignore when considering which files to upload
     required: false
     default: ''
-  add-warning-banner:
-    description: Add a read-only warning banner to synced pages
-    required: false
-    default: 'true'
   modified-files:
     description: Pipe(`|`)-delimited list of files that have been modified (or added or deleted)
     required: true

--- a/wiki_sync.py
+++ b/wiki_sync.py
@@ -93,14 +93,15 @@ def sync_files(files: list[str]) -> bool:
 
         try:
             formatted_content = converter.convert_file_contents(file_path)
-            if os.environ.get('INPUT_ADD-WARNING-BANNER', 'true').lower() == 'true':
-                content = read_only_warning + formatted_content
-            else:
-                content = formatted_content
         except Exception:
             logging.exception('Error converting file %s:', file_path)
             success = False
             continue
+
+        if os.environ.get('INPUT_ADD-WARNING-BANNER', 'true').lower() == 'true':
+            content = read_only_warning + formatted_content
+        else:
+            content = formatted_content
 
         try:
             page_id = create_or_update_pages_for_file(


### PR DESCRIPTION
## Summary

Adds a new optional input `add-warning-banner` that controls whether the read-only warning banner is prepended to synced pages.

- Default: `true` (preserves existing behavior)
- Set to `false` to omit the banner

## Use Case

When Confluence pages are consumed by automated systems (e.g., LLM knowledge bases, search indexers), the warning banner adds noise without value. This option lets users opt out while keeping the default behavior for human-facing documentation.

## Changes

- `action.yml`: Added `add-warning-banner` input parameter
- `wiki_sync.py`: Conditional check before prepending warning