### PR TITLE
chore: Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @KevinGDialpad


### PR DESCRIPTION
Trying to prevent the cleanowners action from adding a non-existent team as a code owner (see #96, #97)